### PR TITLE
Fah 46 setup development workflow

### DIFF
--- a/.dev/server-docker-compose.yml
+++ b/.dev/server-docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  db:
+    image: mysql:lts-oracle
+    mem_limit: 512m
+    container_name: db
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: "dev"
+      MYSQL_DATABASE: findahelper
+    ports:
+      - "3306:3306"
+    volumes:
+      - db_data:/var/lib/mysql
+
+volumes:
+  db_data:

--- a/.dev/start
+++ b/.dev/start
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR=$(cd -- $( dirname -- ${BASH_SOURCE[0]}) &> /dev/null && pwd)
+DOCKER_COMPOSE_FILE=""
+
+rebuild=false
+backend=false
+frontend=false
+
+clean_up () {
+    echo
+    echo "shutting down docker containers"
+    docker compose -f ${SCRIPT_DIR}/${DOCKER_COMPOSE_FILE} down
+}
+
+start_docker_containers () {
+    if $rebuild;then
+        echo "Rebuilding the containers..."
+        docker compose -f ${SCRIPT_DIR}/${DOCKER_COMPOSE_FILE} up --build -d
+    else
+        docker compose -f ${SCRIPT_DIR}/${DOCKER_COMPOSE_FILE} up -d
+    fi
+}
+
+start_backend ()
+{
+    echo "Starting Database for backend development."
+    DOCKER_COMPOSE_FILE="server-docker-compose.yml"
+
+    start_docker_containers
+
+    cd $SCRIPT_DIR
+    cd ..
+    ./gradlew -t build -x test -i
+}
+
+start_frontend ()
+{
+    echo "Starting Database and server for frontend development."
+    DOCKER_COMPOSE_FILE="ui-docker-compose.yml"
+
+    start_docker_containers
+
+    cd $SCRIPT_DIR 
+    cd ../ui
+    npm run dev
+}
+
+start_development () {
+    if $backend; then
+        start_backend
+    elif $frontend; then
+        start_frontend
+    fi
+}
+
+trap clean_up EXIT
+
+while getopts 'rfbh' flag; do
+    case "${flag}" in
+        r)
+            rebuild=true ;;
+        f)
+            frontend=true ;;
+        b)
+            backend=true ;;
+        h)
+            echo "--f = frontend (start db + server)"
+            echo "--b = backend (start db only)"
+            ;;
+    esac
+done
+
+start_development

--- a/.dev/start
+++ b/.dev/start
@@ -66,8 +66,9 @@ while getopts 'rfbh' flag; do
         b)
             backend=true ;;
         h)
-            echo "--f = frontend (start db + server)"
-            echo "--b = backend (start db only)"
+            echo "-f = frontend (start db + server)"
+            echo "-b = backend (start db only)"
+            echo "-r = rebuild local containers"
             ;;
     esac
 done

--- a/.dev/start.bat
+++ b/.dev/start.bat
@@ -71,8 +71,9 @@ if "%~1"=="-r" (
 ) else if "%~1"=="-b" (
     set "backend=true"
 ) else if "%~1"=="-h" (
-    echo --f = frontend (start db + server)
-    echo --b = backend (start db only)
+    echo -f = frontend (start db + server)
+    echo -b = backend (start db only)
+    echo -r = rebuild local containers
     goto :eof
 )
 shift

--- a/.dev/start.bat
+++ b/.dev/start.bat
@@ -8,11 +8,15 @@ set "rebuild=false"
 set "frontend=false"
 set "backend=false"
 
-:: Clean up function
-:clean_up
-echo.
-echo shutting down docker containers
-docker compose -f "%SCRIPT_DIR%\%DOCKER_COMPOSE_FILE%" down
+:: Parse command line arguments
+call :parse_args %*
+
+call :start_development
+if errorlevel 1 (
+    call :clean_up
+)
+
+endlocal
 goto :eof
 
 :: Start docker containers function
@@ -39,7 +43,7 @@ goto :eof
 goto :eof
 
 :: starts server and db running in containers
-:: starts frontend in dev mode 
+:: starts frontend in dev mode
 :start_frontend
     echo Starting Database and server for frontend development.
     set DOCKER_COMPOSE_FILE=ui-docker-compose.yml
@@ -58,6 +62,12 @@ if "%backend%"=="true" (
 ) else if "%frontend%"=="true" (
     call :start_frontend
 )
+
+:: Clean up function
+:clean_up
+echo.
+echo shutting down docker containers
+docker compose -f "%SCRIPT_DIR%\%DOCKER_COMPOSE_FILE%" down
 goto :eof
 
 :: Parse command line arguments

--- a/.dev/start.bat
+++ b/.dev/start.bat
@@ -1,0 +1,90 @@
+@echo off
+setlocal enabledelayedexpansion
+
+:: Initialize variables
+set "SCRIPT_DIR=%~dp0"
+set "DOCKER_COMPOSE_FILE="
+set "rebuild=false"
+set "frontend=false"
+set "backend=false"
+
+:: Clean up function
+:clean_up
+echo.
+echo shutting down docker containers
+docker compose -f "%SCRIPT_DIR%\%DOCKER_COMPOSE_FILE%" down
+goto :eof
+
+:: Start docker containers function
+:start_docker_containers
+if "%rebuild%"=="true" (
+    echo Rebuilding the containers...
+    docker-compose -f "%SCRIPT_DIR%\%DOCKER_COMPOSE_FILE%" up --build -d
+) else (
+    docker-compose -f "%SCRIPT_DIR%\%DOCKER_COMPOSE_FILE%" up -d
+)
+goto :eof
+
+:: starts db running in container
+:: starts server running with watch mode
+:start_backend
+    echo Starting Database for backend development.
+    set DOCKER_COMPOSE_FILE=server-docker-compose.yml
+
+    call :start_docker_containers
+
+    cd %SCRIPT_DIR%
+    cd ..
+    call gradlew.bat -t build -x test -i
+goto :eof
+
+:: starts server and db running in containers
+:: starts frontend in dev mode 
+:start_frontend
+    echo Starting Database and server for frontend development.
+    set DOCKER_COMPOSE_FILE=ui-docker-compose.yml
+
+    call :start_docker_containers
+
+    cd %SCRIPT_DIR%
+    cd ..\ui
+    call npm run dev
+goto :eof
+
+:: Start development function
+:start_development
+if "%backend%"=="true" (
+    call :start_backend
+) else if "%frontend%"=="true" (
+    call :start_frontend
+)
+goto :eof
+
+:: Parse command line arguments
+:parse_args
+if "%~1"=="" goto :args_done
+
+if "%~1"=="-r" (
+    set "rebuild=true"
+) else if "%~1"=="-f" (
+    set "frontend=true"
+) else if "%~1"=="-b" (
+    set "backend=true"
+) else if "%~1"=="-h" (
+    echo --f = frontend (start db + server)
+    echo --b = backend (start db only)
+    goto :eof
+)
+shift
+goto :parse_args
+
+:args_done
+%@Try%
+    call :start_development
+%@EndTry%
+:@Catch
+    call :clean_up
+:@EndCatch
+)
+
+endlocal

--- a/.dev/ui-docker-compose.yml
+++ b/.dev/ui-docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  db:
+    image: mysql:lts-oracle
+    mem_limit: 512m
+    container_name: db
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: "dev"
+      MYSQL_DATABASE: findahelper
+    ports:
+      - "3306:3306"
+    volumes:
+      - db_data:/var/lib/mysql
+
+  server:
+    build:
+      context: ../
+      dockerfile: ./server/Dockerfile
+    container_name: server
+    ports:
+      - "8080:8080"
+    environment:
+      - KTOR_ENV=prod
+    depends_on:
+      - db
+
+volumes:
+  db_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  db:
+    image: mysql:lts-oracle
+    mem_limit: 512m
+    container_name: db
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: "dev"
+      MYSQL_DATABASE: findahelper
+    ports:
+      - "3306:3306"
+    volumes:
+      - db_data:/var/lib/mysql
+
+  server:
+    build:
+      context: .
+      dockerfile: ./server/Dockerfile
+    container_name: server
+    ports:
+      - "8080:8080"
+    environment:
+      - KTOR_ENV=prod
+    depends_on:
+      - db
+
+  ui:
+    build: ./ui
+    container_name: ui
+    ports:
+      - "8085:80"
+volumes:
+  db_data:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,7 +1,8 @@
-FROM gradle:8.14.1-jdk21-alpine AS build
-COPY --chown=gradle:gradle . /home/gradle/src
+FROM amazoncorretto:21-alpine3.21 AS build
+
+COPY . /home/gradle/src
 WORKDIR /home/gradle/src
-RUN gradle build --no-daemon -q
+RUN ./gradlew build --no-daemon
 
 FROM amazoncorretto:21-alpine3.21 AS final
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,15 @@
+FROM gradle:8.14.1-jdk21-alpine AS build
+COPY --chown=gradle:gradle . /home/gradle/src
+WORKDIR /home/gradle/src
+RUN gradle build --no-daemon -q
+
+FROM amazoncorretto:21-alpine3.21 AS final
+
+COPY --from=build /home/gradle/src/server/build/libs/server.jar /app/server.jar
+COPY --from=build /home/gradle/src/server/docs /app/docs
+
+WORKDIR /app
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "server.jar"]

--- a/server/src/main/kotlin/ch/abbts/Main.kt
+++ b/server/src/main/kotlin/ch/abbts/Main.kt
@@ -17,7 +17,7 @@ import ch.abbts.routes.*
 import ch.abbts.config.DatabaseConfig
 
 fun main() {
-    embeddedServer(Netty, host = "0.0.0.0", port = 8080, module = Application::main)
+    embeddedServer(Netty, host = "0.0.0.0", port = 8080, module = Application::main, watchPaths = listOf("classes", "resources"))
             .start(wait = true)
 }
 

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,0 +1,13 @@
+# build stage
+FROM node:22-alpine3.21 AS build
+WORKDIR /app
+COPY package*.json .
+RUN npm install
+COPY . .
+RUN npm run build
+
+# production stage
+FROM nginx:1.28-alpine3.21 AS final
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 8081
+CMD ["nginx", "-g", "daemon off;"]

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -9,5 +9,5 @@ RUN npm run build
 # production stage
 FROM nginx:1.28-alpine3.21 AS final
 COPY --from=build /app/dist /usr/share/nginx/html
-EXPOSE 8081
+EXPOSE 8085
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Ticket Referenz: https://stud-team-find-a-helper.atlassian.net/browse/FAH-46

Für ein einheitliches Development Environment wurde zwischen Frontend und Backend Entwicklung unterschieden.
- Frontend: start file mit `-f` flag ausführen => startet MySql Container + Backend als Container und startet anschliesend die Frontend Applikation in dev mode mit `npm run dev`. Wird mit Ctrl + C abgebrochen, werden die Container wieder runtergefahren.
- Backend: start file mit `-b`flag ausführen => Started nur MySql Container und die Ktor Applikation im "Watchmode"
- optional `-r` flag um die Container bei Veränderungen neu zu builden.